### PR TITLE
#36 fix modal's button event error

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -61,17 +61,21 @@ const HomePage = () => {
     <Container maxWidth="md" sx={{ pt: 3 }}>
       <div style={{ marginBottom: "20px" }}>
         <p>Confirm states</p>
-        {`Name: ${nameRef.current}`}
+        {/* TextFieldの値が空の時に再レンダーすると、refにコンポーネントオブジェクトが代入される。
+        三項演算子を使って、refが文字列の場合のみ出力する */}
+        {`Name: ${typeof nameRef.current === "string" ? nameRef.current : ""}`}
         <br />
         {`KeyBoard: ${keyboard}`}
         <br />
         {`Language: ${language}`}
         <br />
-        {`Code: ${codeRef.current}`}
+        {`Code: ${typeof codeRef.current === "string" ? codeRef.current : ""}`}
         <br />
-        {`MaxLength: ${maxLenRef.current}`}
+        {`Max Length: ${typeof maxLenRef.current === "string" ? maxLenRef.current : ""}`}
         <br />
+
         {`Personal Setting: ${JSON.stringify(personalSetting)}`}
+        <br />
         <br />
       </div>
 
@@ -135,7 +139,13 @@ const HomePage = () => {
                 />
                 <Button
                   onClick={() => {
-                    setPersonalSetting({ language: personalLanguage, code: personalCodeRef.current });
+                    // コードと言語両の方が設定された場合のみ、状態を保持する
+                    if (personalLanguage !== "" && typeof personalCodeRef.current === "string") {
+                      setPersonalSetting({ language: personalLanguage, code: personalCodeRef.current });
+                    } else {
+                      // eslint-disable-next-line no-alert
+                      alert("both input must be filled.");
+                    }
                     toggleModal();
                   }}
                 >

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -58,7 +58,7 @@ const HomePage = () => {
   const toggleModal = (): void => setIsOpen(!isOpen);
 
   return (
-    <Container maxWidth="md" sx={{ pt: 3 }}>
+    <Container maxWidth="md" sx={{ pt: 5, pb: 5 }}>
       <div style={{ marginBottom: "20px" }}>
         <p>Confirm states</p>
         {/* TextFieldの値が空の時に再レンダーすると、refにコンポーネントオブジェクトが代入される。
@@ -144,7 +144,7 @@ const HomePage = () => {
                       setPersonalSetting({ language: personalLanguage, code: personalCodeRef.current });
                     } else {
                       // eslint-disable-next-line no-alert
-                      alert("both input must be filled.");
+                      alert("both inputs must be filled.");
                     }
                     toggleModal();
                   }}


### PR DESCRIPTION
## 概要
下記について修正しました。
HomePageのモーダルで、コード入力欄が空欄のまま確認ボタンを押下するとエラーが発生する
  >Uncaught TypeError: Converting circular structure to JSON
  >--> starting at object with constructor 'HTMLTextAreaElement'
  >| property '__reactFiber$6ppzgpo6bph' -> object with constructor 'FiberNode'
  >--- property 'stateNode' closes the circle at JSON.stringify () at HomePage

## 原因
・モーダル内のコード入力欄が空欄の場合、personalCodeRef 変数の current プロパティにはオブジェクト(HTMLTextAreaElement)が代入される。
・この状態でonClickイベントが発生すると personalSetting 変数( state )の code プロパティにはオブジェクトが代入される
・ personalSetting.code をJSON.stringify で文字列に変換しようとすると循環参照が発生し、エラーとなる

## 対応
・モーダル内のボタンクリックイベントで、personalSetting のプロパティにオブジェクトが代入されないように修正

---メモ----
動作確認用の出力部分で起こっていたエラーです。気持ちが悪かったのでissueとして修正しました。
確認お願いいたします。
また、以前コメントでいただきましたが、HomePage での state 管理は react-hooks-form を使って行うように変更してみようと思います。