### PR TITLE
#84 modify result page

### DIFF
--- a/src/components/NewKeyboard.tsx
+++ b/src/components/NewKeyboard.tsx
@@ -8,9 +8,10 @@ type Props = {
   color?: {
     [keyName: string]: string;
   };
+  onClick?: (keyName: string) => void;
 };
 
-const Keyboard: React.VFC<Props> = ({ keyboardType, color = {} }) => {
+const Keyboard: React.VFC<Props> = ({ keyboardType, color = {}, onClick = () => null }) => {
   const keyData = keyboardData[keyboardType];
   const defaultKeyArr = Object.keys(keyData).filter((keyName) => keyData[keyName].keyType === "default");
   // keyboardのposition(行番号、列番号)でソート。
@@ -84,6 +85,7 @@ const Keyboard: React.VFC<Props> = ({ keyboardType, color = {} }) => {
             width={width}
             height={height}
             id={keyName}
+            onClick={() => onClick(keyName)}
           />
         ) : (
           <path
@@ -105,6 +107,7 @@ const Keyboard: React.VFC<Props> = ({ keyboardType, color = {} }) => {
             z
           `}
             id={keyName}
+            onClick={() => onClick(keyName)}
           />
         )}
         <text

--- a/src/data/keyboardData.ts
+++ b/src/data/keyboardData.ts
@@ -19,6 +19,8 @@ export type KeyData = {
     pushCount?: number;
     missCount?: number;
     timeSecCount?: number;
+    speed?: number;
+    accuracy?: number;
   };
 };
 

--- a/src/pages/ResultPage/FingerStatistics.tsx
+++ b/src/pages/ResultPage/FingerStatistics.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import Box from "@mui/material/Box";
+import React, { useState } from "react";
+import { makeStyles } from "@mui/styles";
+import { Box, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import HandSVG from "../../components/HandSVG";
 import { KeyData } from "../../data/keyboardData";
 
@@ -11,7 +12,39 @@ type Props = {
   data: KeyData;
 };
 
+const useStyles = makeStyles(() => ({
+  container: {
+    width: "90%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  rowFlex: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  rowFlexCenter: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+  },
+  rowFlexEnd: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "end",
+  },
+}));
+
 const FingerStatistics: React.VFC<Props> = ({ data }) => {
+  const classes = useStyles();
+  const [showMode, setShowMode] = useState<"speed" | "accuracy">("speed");
+  const toggleShowMode = (event: React.MouseEvent<HTMLElement>, newMode: "speed" | "accuracy") => {
+    setShowMode(newMode);
+  };
   // キー毎の情報を指ごとの情報に変換する
   const fingerData: {
     [key1 in Hand]: {
@@ -54,17 +87,40 @@ const FingerStatistics: React.VFC<Props> = ({ data }) => {
         );
         const speed = Math.floor((currFinData.pushCountSum - currFinData.missCountSum) / (currFinData.timeSecSum / 60));
 
-        // 使用されていない指の値はNaNになるため、条件分岐で色をつけない。
-        if (Number.isNaN(speed)) fingerData[hand][finger].color = "#e6e6e6";
-        else if (speed >= 200) fingerData[hand][finger].color = "#0000FF";
-        else if (speed >= 150) fingerData[hand][finger].color = "#0099FF";
-        else if (speed >= 100) fingerData[hand][finger].color = "#00CCFF";
-        else if (speed >= 50) fingerData[hand][finger].color = "#00FFFF";
+        if (showMode === "speed") {
+          if (Number.isNaN(speed)) fingerData[hand][finger].color = "#e6e6e6";
+          else if (speed >= 200) fingerData[hand][finger].color = "#0000FF";
+          else if (speed >= 150) fingerData[hand][finger].color = "#0099FF";
+          else if (speed >= 100) fingerData[hand][finger].color = "#00CCFF";
+          else if (speed >= 50) fingerData[hand][finger].color = "#00FFFF";
+          else fingerData[hand][finger].color = "#CCFFFF";
+        } else if (Number.isNaN(accuracy)) fingerData[hand][finger].color = "#e6e6e6";
+        else if (accuracy >= 95) fingerData[hand][finger].color = "#0000FF";
+        else if (accuracy >= 90) fingerData[hand][finger].color = "#0099FF";
+        else if (accuracy >= 80) fingerData[hand][finger].color = "#00CCFF";
+        else if (accuracy >= 70) fingerData[hand][finger].color = "#00FFFF";
         else fingerData[hand][finger].color = "#CCFFFF";
+
+        let fingerText = "";
+        switch (finger) {
+          case "first":
+            fingerText = "人差し指";
+            break;
+          case "second":
+            fingerText = "中指";
+            break;
+          case "third":
+            fingerText = "薬指";
+            break;
+          case "fourth":
+            fingerText = "小指";
+            break;
+          default:
+        }
 
         return (
           <Box key={finger} sx={{ px: 2 }}>
-            {finger} <br />
+            {fingerText} <br />
             {Number.isNaN(accuracy) ? "-" : accuracy}% <br />
             {Number.isNaN(speed) ? "-" : speed}kpm <br />
           </Box>
@@ -78,7 +134,7 @@ const FingerStatistics: React.VFC<Props> = ({ data }) => {
     };
     return (
       <div key={hand}>
-        <h4>{hand} fingers</h4>
+        <h4>{hand === "left" ? "左手" : "右手"}</h4>
         <HandSVG hand={hand} color={color} />
         <Box sx={{ display: "flex", justifyContent: "space-evenly" }}>{eachHandResults}</Box>
       </div>
@@ -87,11 +143,11 @@ const FingerStatistics: React.VFC<Props> = ({ data }) => {
 
   // 後々に手のコンポーネントを作成して、指毎の統計を見やすいデザインとする。
   return (
-    <div>
-      <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-        <h3>Finger Master</h3>
+    <div className={classes.container}>
+      <div className={classes.rowFlex}>
+        <h2>Finger Master(指毎の統計情報)</h2>
         <Box sx={{ display: "flex", alignItems: "center" }}>
-          <p>slow</p>
+          <p>{showMode === "speed" ? "遅い" : "不正確"}</p>
           <Box
             sx={{
               width: 20,
@@ -132,10 +188,21 @@ const FingerStatistics: React.VFC<Props> = ({ data }) => {
               m: 1,
             }}
           />
-          <p>fast</p>
+          <p>{showMode === "speed" ? "速い" : "正確"}</p>
         </Box>
-      </Box>
-      <Box sx={{ display: "flex", justifyContent: "space-between" }}>{statistics}</Box>
+      </div>
+      <div className={classes.rowFlexEnd}>
+        <ToggleButtonGroup exclusive value={showMode} onChange={toggleShowMode}>
+          <ToggleButton value="speed" aria-label="speed result">
+            速さ
+          </ToggleButton>
+          <ToggleButton value="accuracy" aria-label="accuracy result">
+            正確性
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </div>
+      <div className={classes.rowFlexCenter}>{statistics}</div>
+      <br />
     </div>
   );
 };

--- a/src/pages/ResultPage/KeyStatistics.tsx
+++ b/src/pages/ResultPage/KeyStatistics.tsx
@@ -1,31 +1,217 @@
-import React from "react";
+import React, { useState } from "react";
+import { makeStyles } from "@mui/styles";
+import { ToggleButton, ToggleButtonGroup, Box, Card } from "@mui/material";
 import { KeyData } from "../../data/keyboardData";
+import Keyboard from "../../components/NewKeyboard";
 
 type Props = {
   data: KeyData;
+  keyboardType: "jis" | "us" | "mac-jis" | "mac-us";
 };
 
-const KeyStatistics: React.VFC<Props> = ({ data }) => {
-  const statistics = (Object.keys(data) as (keyof typeof data)[]).map((keyName) => {
-    const pushCount = data[keyName].pushCount ?? 0;
-    const missCount = data[keyName].missCount ?? 0;
-    const timeSecCount = data[keyName].timeSecCount ?? 0;
-    const accuracy = Math.floor(((pushCount - missCount) / pushCount) * 100);
-    const speed = Math.floor((pushCount - missCount) / (timeSecCount / 60));
-    if (Number.isNaN(accuracy)) return <div key={keyName}>[{keyName}]: no data</div>;
-    return (
-      <div key={keyName}>
-        [{keyName}]: {accuracy}%, {speed}kpm
-      </div>
+type Color = {
+  [keyName: string]: string;
+};
+
+const useStyles = makeStyles(() => ({
+  container: {
+    width: "90%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  rowFlex: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "start",
+  },
+  rowFlexEnd: {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "end",
+  },
+  keyboardContainer: {
+    width: "70%",
+  },
+}));
+
+const KeyStatistics: React.VFC<Props> = ({ data, keyboardType }) => {
+  const classes = useStyles();
+
+  const calcEachKeyValue = (initialData: KeyData) => {
+    const calcData = initialData;
+    Object.keys(initialData).forEach((keyName) => {
+      const pushCount = initialData[keyName].pushCount ?? 0;
+      const missCount = initialData[keyName].missCount ?? 0;
+      const timeSecCount = initialData[keyName].timeSecCount ?? 0;
+      calcData[keyName].accuracy = Math.floor(((pushCount - missCount) / pushCount) * 100);
+      calcData[keyName].speed = Math.floor((pushCount - missCount) / (timeSecCount / 60));
+    });
+    return calcData;
+  };
+
+  const calcEachKeyButtonColor = (calcData: KeyData) => {
+    const usedKeyArr = Object.keys(calcData).filter((keyName) => !Number.isNaN(calcData[keyName].accuracy));
+    const colorMap: { [key in "speed" | "accuracy"]: Color } = { speed: {}, accuracy: {} };
+    usedKeyArr
+      .filter((keyName) => calcData[keyName].keyType === "default")
+      .forEach((keyName) => {
+        const speedArr = [calcData[keyName].speed as number];
+        const accuracyArr = [calcData[keyName].accuracy as number];
+        usedKeyArr
+          .filter(
+            (k) =>
+              calcData[k].keyType !== "default" &&
+              calcData[keyName].position[0] === calcData[k].position[0] &&
+              calcData[keyName].position[1] === calcData[k].position[1]
+          )
+          .forEach((k) => {
+            speedArr.push(calcData[k].speed as number);
+            accuracyArr.push(calcData[k].accuracy as number);
+          });
+        const avgSpeed =
+          speedArr.reduce((previousValue, currentValue) => previousValue + currentValue) / speedArr.length;
+        const avgAccuracy =
+          accuracyArr.reduce((previousValue, currentValue) => previousValue + currentValue) / accuracyArr.length;
+
+        if (avgSpeed >= 200) colorMap.speed[keyName] = "#0000FF";
+        else if (avgSpeed >= 150) colorMap.speed[keyName] = "#0099FF";
+        else if (avgSpeed >= 100) colorMap.speed[keyName] = "#00CCFF";
+        else if (avgSpeed >= 50) colorMap.speed[keyName] = "#00FFFF";
+        else colorMap.speed[keyName] = "#CCFFFF";
+
+        if (avgAccuracy >= 95) colorMap.accuracy[keyName] = "#0000FF";
+        else if (avgAccuracy >= 90) colorMap.accuracy[keyName] = "#0099FF";
+        else if (avgAccuracy >= 80) colorMap.accuracy[keyName] = "#00CCFF";
+        else if (avgAccuracy >= 70) colorMap.accuracy[keyName] = "#00FFFF";
+        else colorMap.accuracy[keyName] = "#CCFFFF";
+      });
+    return colorMap;
+  };
+
+  const keyData = calcEachKeyValue(data);
+  const colorMap = calcEachKeyButtonColor(keyData);
+  const [showMode, setShowMode] = useState<"speed" | "accuracy">("speed");
+  const [detailKeyArr, setDetailKeyArr] = useState<string[]>([]);
+  const toggleShowMode = (event: React.MouseEvent<HTMLElement>, newMode: "speed" | "accuracy") => {
+    setShowMode(newMode);
+  };
+  const handleDetailKeyArr = (keyName: string) => {
+    const keyArr = [];
+    keyArr.push(keyName);
+    const anotherKey = Object.keys(data).find(
+      (k) =>
+        data[k].keyType !== "default" &&
+        data[keyName].position[0] === data[k].position[0] &&
+        data[keyName].position[1] === data[k].position[1]
     );
+    if (anotherKey !== undefined) keyArr.push(anotherKey);
+    setDetailKeyArr(keyArr);
+  };
+
+  const statistics = Object.keys(keyData).map((keyName) => {
+    const { speed, accuracy, pushCount, missCount, timeSecCount } = keyData[keyName];
+    if (detailKeyArr.includes(keyName)) {
+      if (Number.isNaN(accuracy))
+        return (
+          <div key={keyName}>
+            <strong>Key[{keyName}]</strong>
+            <br />
+            No Data
+            <br />
+            <br />
+          </div>
+        );
+      return (
+        <div key={keyName}>
+          <strong>Key[{keyName}]</strong>
+          <br />
+          精度:{accuracy}%, 速さ:{speed}kpm,
+          <br />
+          押した回数:{pushCount}回, ミスした回数: {missCount ?? 0}回,
+          <br />
+          総経過時間: {timeSecCount}秒,
+          <br />
+          <br />
+        </div>
+      );
+    }
+    return null;
   });
 
   // 後々にキーボードのコンポーネントを作成して、キー毎の統計を見やすいデザインとする。
   return (
-    <div>
-      <h3>Keybord Master</h3>
-      <p>*キー毎の統計情報表示をこれから詳細に開発する。以下は現在の例</p>
-      {statistics}
+    <div className={classes.container}>
+      <div className={classes.rowFlex}>
+        <h2>Keybord Master(キー毎の統計情報)</h2>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <p>{showMode === "speed" ? "遅い" : "不正確"}</p>
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              bgcolor: "#CCFFFF",
+              m: 1,
+            }}
+          />
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              bgcolor: "#00FFFF",
+              m: 1,
+            }}
+          />
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              bgcolor: "#00CCFF",
+              m: 1,
+            }}
+          />
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              bgcolor: "#0099FF",
+              m: 1,
+            }}
+          />
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              bgcolor: "#0000FF",
+              m: 1,
+            }}
+          />
+          <p>{showMode === "speed" ? "早い" : "正確"}</p>
+        </Box>
+      </div>
+      <div className={classes.rowFlexEnd}>
+        <ToggleButtonGroup exclusive value={showMode} onChange={toggleShowMode}>
+          <ToggleButton value="speed" aria-label="speed result">
+            速さ
+          </ToggleButton>
+          <ToggleButton value="accuracy" aria-label="accuracy result">
+            正確性
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </div>
+      <br />
+      <div className={classes.rowFlex}>
+        <Card sx={{ paddingX: 2 }}>
+          <h4>キーボタンを押して詳細情報を表示</h4>
+          {statistics}
+        </Card>
+        <div className={classes.keyboardContainer}>
+          <Keyboard color={colorMap[showMode]} keyboardType={keyboardType} onClick={handleDetailKeyArr} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/ResultPage/ResultPage.tsx
+++ b/src/pages/ResultPage/ResultPage.tsx
@@ -7,8 +7,6 @@ import { KeyData } from "../../data/keyboardData";
 import useProfileContext from "../../hooks/useProfileContext";
 import Header from "../../components/Header";
 
-import Keyboard from "../../components/NewKeyboard";
-
 // 子コンポーネントで使用する予定のデータ（現状はダミー）とその型
 
 type Props = {
@@ -32,21 +30,11 @@ const ResultPage: React.FC<Props> = ({ currGameData }) => {
           <SimpleResult language={userSettings.codeLang} accuracy={currGameData.accuracy} speed={currGameData.speed} />
           {/* <BestScores data={bestScores} /> */}
         </Box>
-        <KeyStatistics data={currGameData.keyData} />
         <br />
+        <hr style={{ width: "90%" }} />
+        <KeyStatistics keyboardType={userSettings.keyboardType} data={currGameData.keyData} />
         <br />
-        <Keyboard keyboardType="jis" />
-        <br />
-        <br />
-        <Keyboard keyboardType="us" />
-        <br />
-        <br />
-        <Keyboard keyboardType="mac-jis" />
-        <br />
-        <br />
-        <Keyboard keyboardType="mac-us" />
-        <br />
-        <br />
+        <hr style={{ width: "90%" }} />
         <FingerStatistcs data={currGameData.keyData} />
       </Box>
     </div>

--- a/src/pages/ResultPage/SimpleResult.tsx
+++ b/src/pages/ResultPage/SimpleResult.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const SimpleResult: React.VFC<Props> = ({ language, accuracy, speed }) => (
   <div>
-    <h3>Result({language})</h3>
+    <h2>Result({language})</h2>
     <Box sx={{ display: "flex", flexDirection: "row", justifyContent: "center" }}>
       <DoughnutChartResult type="accuracy" value={accuracy} />
       <DoughnutChartResult type="speed" value={speed} />


### PR DESCRIPTION
## 概要
Result Pageの統計表示にキーボードコンポーネントを用いたキー統計情報と、修正した指統計情報を記述した。

## 手法
- キー毎の統計情報では同じボタンに最大３キーが存在する（default, shift, option）ため使用されたキーのうち同じボタンの情報があれば平均化してキーボードコンポーネントで色表示できるようにした。
- また、色表示されているキー画像を押すことでキーボタンの詳細な統計情報が出るようにした。
- 色情報はキー毎、指毎の両方で精度での色分けと早さでの色分けが切り替えできるようにトグルボタンを設置した。
<img width="1440" alt="スクリーンショット 2022-04-01 22 55 53" src="https://user-images.githubusercontent.com/69419077/161279565-6f65ff37-665e-4381-8ca2-753fb045e301.png">
<img width="1440" alt="スクリーンショット 2022-04-01 22 56 30" src="https://user-images.githubusercontent.com/69419077/161279590-5bc93ac5-ba37-4988-b5a7-80cdefd19f05.png">