### PR TITLE
#98 modify game page(add start button and fix statistic logic and some bugs)

### DIFF
--- a/src/pages/GamePage/GameHeader.tsx
+++ b/src/pages/GamePage/GameHeader.tsx
@@ -9,7 +9,9 @@ type Props = {
   codeLanguage: CodeLangTypes;
   timeTyping: number;
   missCount: number;
+  started: boolean;
   reset: () => void;
+  start: () => void;
 };
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -22,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const GameHeader: React.VFC<Props> = ({ codeLanguage, timeTyping, missCount, reset }) => {
+const GameHeader: React.VFC<Props> = ({ codeLanguage, timeTyping, missCount, started, reset, start }) => {
   const classes = useStyles();
 
   return (
@@ -40,9 +42,15 @@ const GameHeader: React.VFC<Props> = ({ codeLanguage, timeTyping, missCount, res
               {codeLanguage}
             </Typography>
           </div>
-          <Button variant="contained" color="inherit" sx={{ color: "black" }} onClick={reset}>
-            reset
-          </Button>
+          {started ? (
+            <Button variant="contained" color="inherit" sx={{ color: "black" }} onClick={reset}>
+              reset
+            </Button>
+          ) : (
+            <Button variant="contained" color="primary" sx={{ color: "white" }} onClick={start}>
+              start
+            </Button>
+          )}
         </Toolbar>
       </AppBar>
     </Box>

--- a/src/pages/ResultPage/FingerStatistics.tsx
+++ b/src/pages/ResultPage/FingerStatistics.tsx
@@ -83,9 +83,9 @@ const FingerStatistics: React.VFC<Props> = ({ data }) => {
       .map((finger) => {
         const currFinData = fingerData[hand][finger];
         const accuracy = Math.floor(
-          ((currFinData.pushCountSum - currFinData.missCountSum) / currFinData.pushCountSum) * 100
+          (currFinData.pushCountSum / (currFinData.pushCountSum + currFinData.missCountSum)) * 100
         );
-        const speed = Math.floor((currFinData.pushCountSum - currFinData.missCountSum) / (currFinData.timeSecSum / 60));
+        const speed = Math.floor(currFinData.pushCountSum / (currFinData.timeSecSum / 60));
 
         if (showMode === "speed") {
           if (Number.isNaN(speed)) fingerData[hand][finger].color = "#e6e6e6";

--- a/src/pages/ResultPage/KeyStatistics.tsx
+++ b/src/pages/ResultPage/KeyStatistics.tsx
@@ -47,8 +47,8 @@ const KeyStatistics: React.VFC<Props> = ({ data, keyboardType }) => {
       const pushCount = initialData[keyName].pushCount ?? 0;
       const missCount = initialData[keyName].missCount ?? 0;
       const timeSecCount = initialData[keyName].timeSecCount ?? 0;
-      calcData[keyName].accuracy = Math.floor(((pushCount - missCount) / pushCount) * 100);
-      calcData[keyName].speed = Math.floor((pushCount - missCount) / (timeSecCount / 60));
+      calcData[keyName].accuracy = Math.floor((pushCount / (pushCount + missCount)) * 100);
+      calcData[keyName].speed = Math.floor(pushCount / (timeSecCount / 60));
     });
     return calcData;
   };
@@ -115,10 +115,10 @@ const KeyStatistics: React.VFC<Props> = ({ data, keyboardType }) => {
   const statistics = Object.keys(keyData).map((keyName) => {
     const { speed, accuracy, pushCount, missCount, timeSecCount } = keyData[keyName];
     if (detailKeyArr.includes(keyName)) {
-      if (Number.isNaN(accuracy))
+      if (Number.isNaN(accuracy) || accuracy === 0)
         return (
           <div key={keyName}>
-            <strong>Key[{keyName}]</strong>
+            <strong>Key[ {keyName} ]</strong>
             <br />
             No Data
             <br />
@@ -127,13 +127,13 @@ const KeyStatistics: React.VFC<Props> = ({ data, keyboardType }) => {
         );
       return (
         <div key={keyName}>
-          <strong>Key[{keyName}]</strong>
+          <strong>Key[ {keyName} ]</strong>
           <br />
           精度:{accuracy}%, 速さ:{speed}kpm,
           <br />
-          押した回数:{pushCount}回, ミスした回数: {missCount ?? 0}回,
+          正解回数:{pushCount}回, ミス回数: {missCount ?? 0}回,
           <br />
-          総経過時間: {timeSecCount}秒,
+          平均経過時間: {Math.floor((1000 * (timeSecCount ?? 0)) / (pushCount ?? 0)) / 1000}秒,
           <br />
           <br />
         </div>
@@ -189,7 +189,7 @@ const KeyStatistics: React.VFC<Props> = ({ data, keyboardType }) => {
               m: 1,
             }}
           />
-          <p>{showMode === "speed" ? "早い" : "正確"}</p>
+          <p>{showMode === "speed" ? "速い" : "正確"}</p>
         </Box>
       </div>
       <div className={classes.rowFlexEnd}>


### PR DESCRIPTION
## 概要
ゲームページにスタートボタンを追加。またキー統計情報のバグの修正。その他発見したバグの修正。

## 変更・追加内容
### ゲームスタートボタンの追加
- ゲームがスタートしていない場合はスタートボタン、ゲームがスタート状態になるとリセットボタンになるようにゲームヘッダー部分を修正。
- なお、スタートボタンが押下されてないと、以前のようにコード部分をクリックしてキーボード入力しても受け付けないようになっている。

### バグ修正１：統計情報がマイナスになる
- pushCountを正解時のみに追加するように修正し、さらにスピード、精度の計算式を修正した。

### バグ修正２：タイピングコードの行数が多い場合に最後の行が表示されない。（下画像参照）
<img width="1440" alt="スクリーンショット 2022-04-03 23 38 34" src="https://user-images.githubusercontent.com/69419077/161445674-37ea5202-a1c7-4fb8-bd2f-26b656bb06d8.png">

- gameHeader部とタイピングコード表示部を同じCardコンポーネントから別々のCardコンポーネントでラップされた状態に変更。
- また、このようにしないとゲームスタートボタンが押下されコード表示部にfocusが合わされた場合にゲームヘッダー部がCardコンポーネントの上部へとはみ出し表示されなくなるので、その理由でも本修正は有効。

### バグ修正３：gameDataのkeyDataがリセットされない。
- 修正前はkeyDataがリセットボタンを押されてもリセットされておらず、またブラウザのページをリフレッシュしない限り再度ゲームをした際に前回のcurrGameDataに新たなゲームデータが追加されていた。
- 原因はgame pageのローカルstateのkeyDataに対して初期状態またリセット時にcurrGameDataのkeyDataが参照渡しとなっておりリセットされていないため。
- リセット又はスタートボタンが押された場合にkeyDataの各統計データ値を0にするように修正。

### その他
- resetメソッドがhandleKeyPressメソッド内に定義されており、キーボードイベントが走る度に関数定義が実行されていたので、外のスコープに定義を移動。
- result pageの総経過時間はユーザーに必要ないと思われたので、そのキーの平均経過時間に変更。