### PR TITLE
#109 fixed Select component's defaultValue props inside Myselect comp…

### DIFF
--- a/src/pages/SettingPage/MySelect.tsx
+++ b/src/pages/SettingPage/MySelect.tsx
@@ -1,5 +1,5 @@
 import { SelectChangeEvent, FormControl, InputLabel, MenuItem, Select } from "@mui/material";
-import React from "react";
+import React, { useRef } from "react";
 
 type Props = {
   label: string;
@@ -8,22 +8,26 @@ type Props = {
   onchange: (event: SelectChangeEvent<string>) => void;
 };
 
-const MySelect: React.VFC<Props> = ({ label, options, defaultValue = "", onchange }) => (
-  <FormControl required>
-    <InputLabel>{label}</InputLabel>
-    <Select
-      id={label.toLocaleLowerCase().replace(" ", "-")}
-      label={label.toLocaleLowerCase().replace(" ", "-")}
-      defaultValue={defaultValue}
-      onChange={onchange}
-    >
-      {options.map((item) => (
-        <MenuItem key={item} value={item}>
-          {item}
-        </MenuItem>
-      ))}
-    </Select>
-  </FormControl>
-);
+const MySelect: React.VFC<Props> = ({ label, options, defaultValue = "", onchange }) => {
+  const defaultRef = useRef(defaultValue);
+  return (
+    <FormControl required>
+      <InputLabel>{label}</InputLabel>
+      <Select
+        key={label}
+        id={label.toLocaleLowerCase().replace(" ", "-")}
+        label={label.toLocaleLowerCase().replace(" ", "-")}
+        defaultValue={defaultRef.current ?? ""}
+        onChange={onchange}
+      >
+        {options.map((item) => (
+          <MenuItem key={item} value={item}>
+            {item}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
 
 export default MySelect;


### PR DESCRIPTION
## 概要
Myselectorコンポーネント内、Select コンポーネントにおいて defaultValue Props に対して 変数を設定すると下記エラーが表示される。
- エラー内容
MUI: A component is changing the default value state of an uncontrolled Select after being initialized. To suppress this warning opt to use a controlled Select.

## 対処
Select コンポーネントの defaultValue props に useRefを使ってrefとして変数を渡す。